### PR TITLE
Add simple GI and specular support

### DIFF
--- a/shaders/gbuffers_terrain.fsh
+++ b/shaders/gbuffers_terrain.fsh
@@ -13,6 +13,9 @@ varying vec2 lmcoord;
 varying vec2 texcoord;
 varying vec4 glcolor;
 varying vec4 shadowPos;
+varying vec3 fragWorldPos;
+varying vec3 fragNormal;
+varying vec3 fragViewDir;
 
 //fix artifacts when colored shadows are enabled
 const bool shadowcolor0Nearest = true;
@@ -62,9 +65,8 @@ void main() {
 	}
         color *= texture2D(lightmap, lm);
 
-        // Apply experimental Latinium lighting
-        // TODO: supply real world position, normal and view direction
-        color.rgb = applyLatiniumLighting(color.rgb, vec3(0.0), vec3(0.0), vec3(0.0));
+        // Apply experimental Latinium lighting with world position and normal
+        color.rgb = applyLatiniumLighting(color.rgb, fragWorldPos, fragNormal, fragViewDir);
 
 /* DRAWBUFFERS:0 */
 	gl_FragData[0] = color; //gcolor

--- a/shaders/gbuffers_terrain.vsh
+++ b/shaders/gbuffers_terrain.vsh
@@ -12,6 +12,9 @@ varying vec2 lmcoord;
 varying vec2 texcoord;
 varying vec4 glcolor;
 varying vec4 shadowPos;
+varying vec3 fragWorldPos;
+varying vec3 fragNormal;
+varying vec3 fragViewDir;
 
 #include "/distort.glsl"
 
@@ -27,7 +30,10 @@ void main() {
 		if (mc_Entity.x == 10000.0) lightDot = 1.0;
 	#endif
 
-	vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
+        vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
+        fragViewDir = normalize(-viewPos.xyz);
+        fragWorldPos = (gbufferModelViewInverse * viewPos).xyz;
+        fragNormal = normalize(mat3(gbufferModelViewInverse) * (gl_NormalMatrix * gl_Normal));
 	if (lightDot > 0.0) { //vertex is facing towards the sun
 		vec4 playerPos = gbufferModelViewInverse * viewPos;
 		shadowPos = shadowProjection * (shadowModelView * playerPos); //convert to shadow ndc space.

--- a/shaders/gbuffers_textured.fsh
+++ b/shaders/gbuffers_textured.fsh
@@ -15,6 +15,8 @@ varying vec2 lmcoord;
 varying vec2 texcoord;
 varying vec4 glcolor;
 varying vec3 shadowPos; //normals don't exist for particles
+varying vec3 fragWorldPos;
+varying vec3 fragViewDir;
 
 //fix artifacts when colored shadows are enabled
 const bool shadowcolor0Nearest = true;
@@ -57,9 +59,8 @@ void main() {
 	}
         color *= texture2D(lightmap, lm);
 
-        // Apply experimental Latinium lighting
-        // TODO: supply real world position, normal and view direction
-        color.rgb = applyLatiniumLighting(color.rgb, vec3(0.0), vec3(0.0), vec3(0.0));
+        // Apply experimental Latinium lighting; particles lack normals
+        color.rgb = applyLatiniumLighting(color.rgb, fragWorldPos, vec3(0.0), fragViewDir);
 
 /* DRAWBUFFERS:0 */
 	gl_FragData[0] = color; //gcolor

--- a/shaders/gbuffers_textured.vsh
+++ b/shaders/gbuffers_textured.vsh
@@ -10,6 +10,8 @@ varying vec2 lmcoord;
 varying vec2 texcoord;
 varying vec4 glcolor;
 varying vec3 shadowPos; //normals don't exist for particles
+varying vec3 fragWorldPos;
+varying vec3 fragViewDir;
 
 #include "/distort.glsl"
 
@@ -18,8 +20,10 @@ void main() {
 	lmcoord  = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
 	glcolor = gl_Color;
 
-	vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
-	vec4 playerPos = gbufferModelViewInverse * viewPos;
+        vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
+        fragViewDir = normalize(-viewPos.xyz);
+        fragWorldPos = (gbufferModelViewInverse * viewPos).xyz;
+        vec4 playerPos = gbufferModelViewInverse * viewPos;
 	shadowPos = (shadowProjection * (shadowModelView * playerPos)).xyz; //convert to shadow ndc space.
 	float bias = computeBias(shadowPos);
 	shadowPos = distort(shadowPos); //apply shadow distortion.

--- a/shaders/latinium_lighting.glsl
+++ b/shaders/latinium_lighting.glsl
@@ -6,6 +6,7 @@
 #define LATINIUM_USE_GI
 
 uniform vec3 latiniumAmbientColor; // Configurable ambient term
+uniform sampler2D latiniumGIEnvMap; // Environment map used for simple GI
 
 // Future implementation of ambient occlusion
 float computeAmbientOcclusion(vec3 worldPos, vec3 normal) {
@@ -13,16 +14,26 @@ float computeAmbientOcclusion(vec3 worldPos, vec3 normal) {
     return 1.0;
 }
 
-// Future implementation of specular highlights
+// Basic Blinn-Phong style specular highlight
 vec3 computeSpecular(vec3 viewDir, vec3 normal) {
-    // TODO: add specular lighting
+#ifdef LATINIUM_USE_SPECULAR
+    vec3 refl = reflect(-viewDir, normal);
+    float spec = pow(max(refl.z, 0.0), 32.0);
+    return vec3(spec);
+#else
     return vec3(0.0);
+#endif
 }
 
-// Future global illumination placeholder
+// Simple environment map based GI approximation
 vec3 computeGlobalIllumination(vec3 worldPos, vec3 normal) {
-    // TODO: implement ReSTIR based GI
+#ifdef LATINIUM_USE_GI
+    vec2 envUV = normal.xy * 0.5 + 0.5;
+    vec3 envColor = texture2D(latiniumGIEnvMap, envUV).rgb;
+    return envColor * 0.2; // subtle contribution
+#else
     return vec3(0.0);
+#endif
 }
 
 // Entry point used by fragment shaders


### PR DESCRIPTION
## Summary
- add world position and view direction varyings
- compute basic specular highlights
- approximate global illumination from an environment map
- pass lighting parameters to lighting helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873f7f45fe08330a0d82ee423e3ef31