### PR TITLE
Update legacy shaders to GLSL 3.30

### DIFF
--- a/shaders/composite.vsh
+++ b/shaders/composite.vsh
@@ -1,8 +1,15 @@
-#version 120
+#version 330
 
-varying vec2 texcoord;
+in vec3 in_pos;
+in vec2 in_uv;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec2 texcoord;
 
 void main() {
-	gl_Position = ftransform();
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
+        vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+        gl_Position = projectionMatrix * viewPos;
+        texcoord = in_uv;
 }

--- a/shaders/gbuffers_armor_glint.fsh
+++ b/shaders/gbuffers_armor_glint.fsh
@@ -1,16 +1,18 @@
-#version 120
+#version 330
 
 uniform sampler2D lightmap;
 uniform sampler2D texture;
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec2 lmcoord;
+in vec2 texcoord;
+in vec4 glcolor;
+
+out vec4 out_color;
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
-	color *= texture2D(lightmap, lmcoord);
+        vec4 color = texture(texture, texcoord) * glcolor;
+        color *= texture(lightmap, lmcoord);
 
 /* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+        out_color = color; // gcolor
 }

--- a/shaders/gbuffers_armor_glint.vsh
+++ b/shaders/gbuffers_armor_glint.vsh
@@ -1,13 +1,21 @@
-#version 120
+#version 330
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec3 in_pos;
+in vec2 in_uv;
+in vec4 in_color;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec2 lmcoord;
+out vec2 texcoord;
+out vec4 glcolor;
 
 void main() {
-	//use same transforms as entities and hand to avoid z-fighting issues
-	gl_Position = gl_ProjectionMatrix * (gl_ModelViewMatrix * gl_Vertex);
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
-	lmcoord  = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
-	glcolor = gl_Color;
+        //use same transforms as entities and hand to avoid z-fighting issues
+        vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+        gl_Position = projectionMatrix * viewPos;
+        texcoord = in_uv;
+        lmcoord = in_uv;
+        glcolor = in_color;
 }

--- a/shaders/gbuffers_basic.fsh
+++ b/shaders/gbuffers_basic.fsh
@@ -1,14 +1,15 @@
-#version 120
+#version 330
 
 uniform sampler2D lightmap;
 
-varying vec2 lmcoord;
-varying vec4 glcolor;
+in vec2 lmcoord;
+in vec4 glcolor;
+
+out vec4 out_color;
 
 void main() {
-	vec4 color = glcolor;
-	color *= texture2D(lightmap, lmcoord);
+    vec4 color = glcolor;
+    color *= texture(lightmap, lmcoord);
 
-/* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+    out_color = color; // gcolor
 }

--- a/shaders/gbuffers_basic.vsh
+++ b/shaders/gbuffers_basic.vsh
@@ -1,10 +1,18 @@
-#version 120
+#version 330
 
-varying vec2 lmcoord;
-varying vec4 glcolor;
+in vec3 in_pos;
+in vec2 in_uv;
+in vec4 in_color;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec2 lmcoord;
+out vec4 glcolor;
 
 void main() {
-	gl_Position = ftransform();
-	lmcoord  = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
-	glcolor = gl_Color;
+    vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+    gl_Position = projectionMatrix * viewPos;
+    lmcoord = in_uv;
+    glcolor = in_color;
 }

--- a/shaders/gbuffers_beaconbeam.fsh
+++ b/shaders/gbuffers_beaconbeam.fsh
@@ -1,13 +1,15 @@
-#version 120
+#version 330
 
 uniform sampler2D texture;
 
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec2 texcoord;
+in vec4 glcolor;
+
+out vec4 out_color;
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
+        vec4 color = texture(texture, texcoord) * glcolor;
 
 /* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+        out_color = color; // gcolor
 }

--- a/shaders/gbuffers_beaconbeam.vsh
+++ b/shaders/gbuffers_beaconbeam.vsh
@@ -1,10 +1,18 @@
-#version 120
+#version 330
 
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec3 in_pos;
+in vec2 in_uv;
+in vec4 in_color;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec2 texcoord;
+out vec4 glcolor;
 
 void main() {
-	gl_Position = ftransform();
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
-	glcolor = gl_Color;
+        vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+        gl_Position = projectionMatrix * viewPos;
+        texcoord = in_uv;
+        glcolor = in_color;
 }

--- a/shaders/gbuffers_clouds.fsh
+++ b/shaders/gbuffers_clouds.fsh
@@ -1,13 +1,15 @@
-#version 120
+#version 330
 
 uniform sampler2D texture;
 
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec2 texcoord;
+in vec4 glcolor;
+
+out vec4 out_color;
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
+        vec4 color = texture(texture, texcoord) * glcolor;
 
 /* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+        out_color = color; // gcolor
 }

--- a/shaders/gbuffers_clouds.vsh
+++ b/shaders/gbuffers_clouds.vsh
@@ -1,10 +1,18 @@
-#version 120
+#version 330
 
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec3 in_pos;
+in vec2 in_uv;
+in vec4 in_color;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec2 texcoord;
+out vec4 glcolor;
 
 void main() {
-	gl_Position = ftransform();
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
-	glcolor = gl_Color;
+        vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+        gl_Position = projectionMatrix * viewPos;
+        texcoord = in_uv;
+        glcolor = in_color;
 }

--- a/shaders/gbuffers_entities.fsh
+++ b/shaders/gbuffers_entities.fsh
@@ -1,4 +1,4 @@
-#version 120
+#version 330
 
 #define COLORED_SHADOWS 1 //0: Stained glass will cast ordinary shadows. 1: Stained glass will cast colored shadows. 2: Stained glass will not cast any shadows. [0 1 2]
 #define SHADOW_BRIGHTNESS 0.75 //Light levels are multiplied by this number when the surface is in shadows [0.00 0.05 0.10 0.15 0.20 0.25 0.30 0.35 0.40 0.45 0.50 0.55 0.60 0.65 0.70 0.75 0.80 0.85 0.90 0.95 1.00]
@@ -9,10 +9,12 @@ uniform sampler2D shadowtex0;
 uniform sampler2D shadowtex1;
 uniform sampler2D texture;
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
-varying vec4 shadowPos;
+in vec2 lmcoord;
+in vec2 texcoord;
+in vec4 glcolor;
+in vec4 shadowPos;
+
+out vec4 out_color;
 
 //fix artifacts when colored shadows are enabled
 const bool shadowcolor0Nearest = true;
@@ -20,17 +22,17 @@ const bool shadowtex0Nearest = true;
 const bool shadowtex1Nearest = true;
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
-	vec2 lm = lmcoord;
+        vec4 color = texture(texture, texcoord) * glcolor;
+        vec2 lm = lmcoord;
 	if (shadowPos.w > 0.0) {
 		//surface is facing towards shadowLightPosition
 		#if COLORED_SHADOWS == 0
 			//for normal shadows, only consider the closest thing to the sun,
 			//regardless of whether or not it's opaque.
-			if (texture2D(shadowtex0, shadowPos.xy).r < shadowPos.z) {
+                        if (texture(shadowtex0, shadowPos.xy).r < shadowPos.z) {
 		#else
 			//for invisible and colored shadows, first check the closest OPAQUE thing to the sun.
-			if (texture2D(shadowtex1, shadowPos.xy).r < shadowPos.z) {
+                        if (texture(shadowtex1, shadowPos.xy).r < shadowPos.z) {
 		#endif
 			//surface is in shadows. reduce light level.
 			lm.y *= SHADOW_BRIGHTNESS;
@@ -41,10 +43,10 @@ void main() {
 			#if COLORED_SHADOWS == 1
 				//when colored shadows are enabled and there's nothing OPAQUE between us and the sun,
 				//perform a 2nd check to see if there's anything translucent between us and the sun.
-				if (texture2D(shadowtex0, shadowPos.xy).r < shadowPos.z) {
+                                if (texture(shadowtex0, shadowPos.xy).r < shadowPos.z) {
 					//surface has translucent object between it and the sun. modify its color.
 					//if the block light is high, modify the color less.
-					vec4 shadowLightColor = texture2D(shadowcolor0, shadowPos.xy);
+                                        vec4 shadowLightColor = texture(shadowcolor0, shadowPos.xy);
 					//make colors more intense when the shadow light color is more opaque.
 					shadowLightColor.rgb = mix(vec3(1.0), shadowLightColor.rgb, shadowLightColor.a);
 					//also make colors less intense when the block light level is high.
@@ -55,8 +57,7 @@ void main() {
 			#endif
 		}
 	}
-	color *= texture2D(lightmap, lm);
+        color *= texture(lightmap, lm);
 
-/* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+        out_color = color; // gcolor
 }

--- a/shaders/gbuffers_entities.vsh
+++ b/shaders/gbuffers_entities.vsh
@@ -1,46 +1,49 @@
-#version 120
+#version 330
+
+in vec3 in_pos;
+in vec3 in_normal;
+in vec2 in_uv;
+in vec4 in_color;
 
 uniform mat4 gbufferModelView;
 uniform mat4 gbufferModelViewInverse;
 uniform mat4 shadowModelView;
 uniform mat4 shadowProjection;
 uniform vec3 shadowLightPosition;
+uniform mat4 projectionMatrix;
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
-varying vec4 shadowPos;
+out vec2 lmcoord;
+out vec2 texcoord;
+out vec4 glcolor;
+out vec4 shadowPos;
 
 #include "/distort.glsl"
 
 void main() {
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
-	lmcoord  = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
-	glcolor = gl_Color;
-	
-	vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
-	float lightDot = dot(normalize(shadowLightPosition), normalize(gl_NormalMatrix * gl_Normal));
-	if (lightDot > 0.0) { //vertex is facing towards the sun.
-		vec4 playerPos = gbufferModelViewInverse * viewPos;
-		shadowPos = shadowProjection * (shadowModelView * playerPos); //convert to shadow ndc space.
-		float bias = computeBias(shadowPos.xyz);
-		shadowPos.xyz = distort(shadowPos.xyz); //apply shadow distortion
-		shadowPos.xyz = shadowPos.xyz * 0.5 + 0.5; //convert from -1 ~ +1 to 0 ~ 1
-		//apply shadow bias.
-		#ifdef NORMAL_BIAS
-			//we are allowed to project the normal because shadowProjection is purely a scalar matrix.
-			//a faster way to apply the same operation would be to multiply by shadowProjection[0][0].
-			vec4 normal = shadowProjection * vec4(mat3(shadowModelView) * (mat3(gbufferModelViewInverse) * (gl_NormalMatrix * gl_Normal)), 1.0);
-			shadowPos.xyz += normal.xyz / normal.w * bias;
-		#else
-			shadowPos.z -= bias / abs(lightDot);
-		#endif
-	}
-	else { //vertex is facing away from the sun
-		lmcoord.y *= SHADOW_BRIGHTNESS; //guaranteed to be in shadows. reduce light level immediately.
-		shadowPos = vec4(0.0); //mark that this vertex does not need to check the shadow map.
-	}
-	shadowPos.w = lightDot;
-	//use consistent transforms for entities and hand so that armor glint doesn't have z-fighting issues.
-	gl_Position = gl_ProjectionMatrix * viewPos;
+    texcoord = in_uv;
+    lmcoord  = in_uv;
+    glcolor = in_color;
+
+    vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+    vec3 normalView = normalize((gbufferModelView * vec4(in_normal, 0.0)).xyz);
+    float lightDot = dot(normalize(shadowLightPosition), normalView);
+    if (lightDot > 0.0) {
+        vec4 playerPos = gbufferModelViewInverse * viewPos;
+        shadowPos = shadowProjection * (shadowModelView * playerPos);
+        float bias = computeBias(shadowPos.xyz);
+        shadowPos.xyz = distort(shadowPos.xyz);
+        shadowPos.xyz = shadowPos.xyz * 0.5 + 0.5;
+#ifdef NORMAL_BIAS
+        vec3 worldNormal = mat3(gbufferModelViewInverse) * normalView;
+        vec4 normal = shadowProjection * vec4(mat3(shadowModelView) * worldNormal, 1.0);
+        shadowPos.xyz += normal.xyz / normal.w * bias;
+#else
+        shadowPos.z -= bias / abs(lightDot);
+#endif
+    } else {
+        lmcoord.y *= SHADOW_BRIGHTNESS;
+        shadowPos = vec4(0.0);
+    }
+    shadowPos.w = lightDot;
+    gl_Position = projectionMatrix * viewPos;
 }

--- a/shaders/gbuffers_hand.fsh
+++ b/shaders/gbuffers_hand.fsh
@@ -1,4 +1,4 @@
-#version 120
+#version 330
 
 #define COLORED_SHADOWS 1 //0: Stained glass will cast ordinary shadows. 1: Stained glass will cast colored shadows. 2: Stained glass will not cast any shadows. [0 1 2]
 #define SHADOW_BRIGHTNESS 0.75 //Light levels are multiplied by this number when the surface is in shadows [0.00 0.05 0.10 0.15 0.20 0.25 0.30 0.35 0.40 0.45 0.50 0.55 0.60 0.65 0.70 0.75 0.80 0.85 0.90 0.95 1.00]
@@ -9,10 +9,12 @@ uniform sampler2D shadowtex0;
 uniform sampler2D shadowtex1;
 uniform sampler2D texture;
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
-varying vec4 shadowPos;
+in vec2 lmcoord;
+in vec2 texcoord;
+in vec4 glcolor;
+in vec4 shadowPos;
+
+out vec4 out_color;
 
 //fix artifacts when colored shadows are enabled
 const bool shadowcolor0Nearest = true;
@@ -20,17 +22,17 @@ const bool shadowtex0Nearest = true;
 const bool shadowtex1Nearest = true;
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
-	vec2 lm = lmcoord;
+        vec4 color = texture(texture, texcoord) * glcolor;
+        vec2 lm = lmcoord;
 	if (shadowPos.w > 0.0) {
 		//surface is facing towards shadowLightPosition
 		#if COLORED_SHADOWS == 0
 			//for normal shadows, only consider the closest thing to the sun,
 			//regardless of whether or not it's opaque.
-			if (texture2D(shadowtex0, shadowPos.xy).r < shadowPos.z) {
+                        if (texture(shadowtex0, shadowPos.xy).r < shadowPos.z) {
 		#else
 			//for invisible and colored shadows, first check the closest OPAQUE thing to the sun.
-			if (texture2D(shadowtex1, shadowPos.xy).r < shadowPos.z) {
+                        if (texture(shadowtex1, shadowPos.xy).r < shadowPos.z) {
 		#endif
 			//surface is in shadows. reduce light level.
 			lm.y *= SHADOW_BRIGHTNESS;
@@ -41,10 +43,10 @@ void main() {
 			#if COLORED_SHADOWS == 1
 				//when colored shadows are enabled and there's nothing OPAQUE between us and the sun,
 				//perform a 2nd check to see if there's anything translucent between us and the sun.
-				if (texture2D(shadowtex0, shadowPos.xy).r < shadowPos.z) {
+                                if (texture(shadowtex0, shadowPos.xy).r < shadowPos.z) {
 					//surface has translucent object between it and the sun. modify its color.
 					//if the block light is high, modify the color less.
-					vec4 shadowLightColor = texture2D(shadowcolor0, shadowPos.xy);
+                                        vec4 shadowLightColor = texture(shadowcolor0, shadowPos.xy);
 					//make colors more intense when the shadow light color is more opaque.
 					shadowLightColor.rgb = mix(vec3(1.0), shadowLightColor.rgb, shadowLightColor.a);
 					//also make colors less intense when the block light level is high.
@@ -55,8 +57,7 @@ void main() {
 			#endif
 		}
 	}
-	color *= texture2D(lightmap, lm);
+        color *= texture(lightmap, lm);
 
-/* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+        out_color = color; // gcolor
 }

--- a/shaders/gbuffers_skybasic.fsh
+++ b/shaders/gbuffers_skybasic.fsh
@@ -1,4 +1,4 @@
-#version 120
+#version 330
 
 uniform float viewHeight;
 uniform float viewWidth;
@@ -7,7 +7,9 @@ uniform mat4 gbufferProjectionInverse;
 uniform vec3 fogColor;
 uniform vec3 skyColor;
 
-varying vec4 starData; //rgb = star color, a = flag for weather or not this pixel is a star.
+in vec4 starData; //rgb = star color, a = flag for weather or not this pixel is a star.
+
+out vec4 out_color;
 
 const float sunPathRotation = 30.0;
 
@@ -32,5 +34,5 @@ void main() {
 	}
 
 /* DRAWBUFFERS:0 */
-	gl_FragData[0] = vec4(color, 1.0); //gcolor
+        out_color = vec4(color, 1.0); // gcolor
 }

--- a/shaders/gbuffers_skybasic.vsh
+++ b/shaders/gbuffers_skybasic.vsh
@@ -1,8 +1,15 @@
-#version 120
+#version 330
 
-varying vec4 starData; //rgb = star color, a = flag for weather or not this pixel is a star.
+in vec3 in_pos;
+in vec4 in_color;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec4 starData; //rgb = star color, a = flag for weather or not this pixel is a star.
 
 void main() {
-	gl_Position = ftransform();
-	starData = vec4(gl_Color.rgb, float(gl_Color.r == gl_Color.g && gl_Color.g == gl_Color.b && gl_Color.r > 0.0));
+        vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+        gl_Position = projectionMatrix * viewPos;
+        starData = vec4(in_color.rgb, float(in_color.r == in_color.g && in_color.g == in_color.b && in_color.r > 0.0));
 }

--- a/shaders/gbuffers_skytextured.fsh
+++ b/shaders/gbuffers_skytextured.fsh
@@ -1,13 +1,15 @@
-#version 120
+#version 330
 
 uniform sampler2D texture;
 
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec2 texcoord;
+in vec4 glcolor;
+
+out vec4 out_color;
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
+        vec4 color = texture(texture, texcoord) * glcolor;
 
 /* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+        out_color = color; // gcolor
 }

--- a/shaders/gbuffers_skytextured.vsh
+++ b/shaders/gbuffers_skytextured.vsh
@@ -1,10 +1,18 @@
-#version 120
+#version 330
 
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec3 in_pos;
+in vec2 in_uv;
+in vec4 in_color;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec2 texcoord;
+out vec4 glcolor;
 
 void main() {
-	gl_Position = ftransform();
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
-	glcolor = gl_Color;
+        vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+        gl_Position = projectionMatrix * viewPos;
+        texcoord = in_uv;
+        glcolor = in_color;
 }

--- a/shaders/gbuffers_terrain.fsh
+++ b/shaders/gbuffers_terrain.fsh
@@ -1,4 +1,4 @@
-#version 120
+#version 330
 
 #define COLORED_SHADOWS 1 //0: Stained glass will cast ordinary shadows. 1: Stained glass will cast colored shadows. 2: Stained glass will not cast any shadows. [0 1 2]
 #define SHADOW_BRIGHTNESS 0.75 //Light levels are multiplied by this number when the surface is in shadows [0.00 0.05 0.10 0.15 0.20 0.25 0.30 0.35 0.40 0.45 0.50 0.55 0.60 0.65 0.70 0.75 0.80 0.85 0.90 0.95 1.00]
@@ -9,13 +9,15 @@ uniform sampler2D shadowtex0;
 uniform sampler2D shadowtex1;
 uniform sampler2D texture;
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
-varying vec4 shadowPos;
-varying vec3 fragWorldPos;
-varying vec3 fragNormal;
-varying vec3 fragViewDir;
+in vec2 lmcoord;
+in vec2 texcoord;
+in vec4 glcolor;
+in vec4 shadowPos;
+in vec3 fragWorldPos;
+in vec3 fragNormal;
+in vec3 fragViewDir;
+
+out vec4 out_color;
 
 //fix artifacts when colored shadows are enabled
 const bool shadowcolor0Nearest = true;
@@ -28,17 +30,17 @@ const bool shadowtex1Nearest = true;
 #include "/latinium_lighting.glsl"
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
-	vec2 lm = lmcoord;
+        vec4 color = texture(texture, texcoord) * glcolor;
+        vec2 lm = lmcoord;
 	if (shadowPos.w > 0.0) {
 		//surface is facing towards shadowLightPosition
 		#if COLORED_SHADOWS == 0
 			//for normal shadows, only consider the closest thing to the sun,
 			//regardless of whether or not it's opaque.
-			if (texture2D(shadowtex0, shadowPos.xy).r < shadowPos.z) {
+                        if (texture(shadowtex0, shadowPos.xy).r < shadowPos.z) {
 		#else
 			//for invisible and colored shadows, first check the closest OPAQUE thing to the sun.
-			if (texture2D(shadowtex1, shadowPos.xy).r < shadowPos.z) {
+                        if (texture(shadowtex1, shadowPos.xy).r < shadowPos.z) {
 		#endif
 			//surface is in shadows. reduce light level.
 			lm.y *= SHADOW_BRIGHTNESS;
@@ -49,10 +51,10 @@ void main() {
 			#if COLORED_SHADOWS == 1
 				//when colored shadows are enabled and there's nothing OPAQUE between us and the sun,
 				//perform a 2nd check to see if there's anything translucent between us and the sun.
-				if (texture2D(shadowtex0, shadowPos.xy).r < shadowPos.z) {
+                                if (texture(shadowtex0, shadowPos.xy).r < shadowPos.z) {
 					//surface has translucent object between it and the sun. modify its color.
 					//if the block light is high, modify the color less.
-					vec4 shadowLightColor = texture2D(shadowcolor0, shadowPos.xy);
+                                        vec4 shadowLightColor = texture(shadowcolor0, shadowPos.xy);
 					//make colors more intense when the shadow light color is more opaque.
 					shadowLightColor.rgb = mix(vec3(1.0), shadowLightColor.rgb, shadowLightColor.a);
 					//also make colors less intense when the block light level is high.
@@ -63,11 +65,11 @@ void main() {
 			#endif
 		}
 	}
-        color *= texture2D(lightmap, lm);
+        color *= texture(lightmap, lm);
 
         // Apply experimental Latinium lighting with world position and normal
         color.rgb = applyLatiniumLighting(color.rgb, fragWorldPos, fragNormal, fragViewDir);
 
 /* DRAWBUFFERS:0 */
-	gl_FragData[0] = color; //gcolor
+        out_color = color; // gcolor
 }

--- a/shaders/gbuffers_terrain.vsh
+++ b/shaders/gbuffers_terrain.vsh
@@ -1,42 +1,48 @@
-#version 120
+#version 330
 
-attribute vec4 mc_Entity;
+in vec3 in_pos;
+in vec3 in_normal;
+in vec2 in_uv;
+in vec4 in_color;
+in vec4 mc_Entity;
 
 uniform mat4 gbufferModelView;
 uniform mat4 gbufferModelViewInverse;
 uniform mat4 shadowModelView;
 uniform mat4 shadowProjection;
 uniform vec3 shadowLightPosition;
+uniform mat4 projectionMatrix;
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
-varying vec4 shadowPos;
-varying vec3 fragWorldPos;
-varying vec3 fragNormal;
-varying vec3 fragViewDir;
+out vec2 lmcoord;
+out vec2 texcoord;
+out vec4 glcolor;
+out vec4 shadowPos;
+out vec3 fragWorldPos;
+out vec3 fragNormal;
+out vec3 fragViewDir;
 
 #include "/distort.glsl"
 
 void main() {
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
-	lmcoord  = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
-	glcolor = gl_Color;
+        texcoord = in_uv;
+        lmcoord  = in_uv;
+        glcolor = in_color;
 
-	float lightDot = dot(normalize(shadowLightPosition), normalize(gl_NormalMatrix * gl_Normal));
+        vec3 normalView = normalize((gbufferModelView * vec4(in_normal, 0.0)).xyz);
+        float lightDot = dot(normalize(shadowLightPosition), normalView);
 	#ifdef EXCLUDE_FOLIAGE
 		//when EXCLUDE_FOLIAGE is enabled, act as if foliage is always facing towards the sun.
 		//in other words, don't darken the back side of it unless something else is casting a shadow on it.
 		if (mc_Entity.x == 10000.0) lightDot = 1.0;
 	#endif
 
-        vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
+        vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
         fragViewDir = normalize(-viewPos.xyz);
         fragWorldPos = (gbufferModelViewInverse * viewPos).xyz;
-        fragNormal = normalize(mat3(gbufferModelViewInverse) * (gl_NormalMatrix * gl_Normal));
+        fragNormal = normalize(mat3(gbufferModelViewInverse) * normalView);
 	if (lightDot > 0.0) { //vertex is facing towards the sun
-		vec4 playerPos = gbufferModelViewInverse * viewPos;
-		shadowPos = shadowProjection * (shadowModelView * playerPos); //convert to shadow ndc space.
+                vec4 playerPos = gbufferModelViewInverse * viewPos;
+                shadowPos = shadowProjection * (shadowModelView * playerPos); //convert to shadow ndc space.
 		float bias = computeBias(shadowPos.xyz);
 		shadowPos.xyz = distort(shadowPos.xyz); //apply shadow distortion
 		shadowPos.xyz = shadowPos.xyz * 0.5 + 0.5; //convert from -1 ~ +1 to 0 ~ 1
@@ -44,7 +50,8 @@ void main() {
 		#ifdef NORMAL_BIAS
 			//we are allowed to project the normal because shadowProjection is purely a scalar matrix.
 			//a faster way to apply the same operation would be to multiply by shadowProjection[0][0].
-			vec4 normal = shadowProjection * vec4(mat3(shadowModelView) * (mat3(gbufferModelViewInverse) * (gl_NormalMatrix * gl_Normal)), 1.0);
+                        vec3 worldNormal = mat3(gbufferModelViewInverse) * normalView;
+                        vec4 normal = shadowProjection * vec4(mat3(shadowModelView) * worldNormal, 1.0);
 			shadowPos.xyz += normal.xyz / normal.w * bias;
 		#else
 			shadowPos.z -= bias / abs(lightDot);
@@ -55,5 +62,5 @@ void main() {
 		shadowPos = vec4(0.0); //mark that this vertex does not need to check the shadow map.
 	}
 	shadowPos.w = lightDot;
-	gl_Position = gl_ProjectionMatrix * viewPos;
+        gl_Position = projectionMatrix * viewPos;
 }

--- a/shaders/gbuffers_weather.vsh
+++ b/shaders/gbuffers_weather.vsh
@@ -1,10 +1,18 @@
-#version 120
+#version 330
 
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec3 in_pos;
+in vec2 in_uv;
+in vec4 in_color;
+
+uniform mat4 gbufferModelView;
+uniform mat4 projectionMatrix;
+
+out vec2 texcoord;
+out vec4 glcolor;
 
 void main() {
-	gl_Position = ftransform();
-	texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
-	glcolor = gl_Color;
+    vec4 viewPos = gbufferModelView * vec4(in_pos, 1.0);
+    gl_Position = projectionMatrix * viewPos;
+    texcoord = in_uv;
+    glcolor = in_color;
 }

--- a/shaders/shadow.fsh
+++ b/shaders/shadow.fsh
@@ -1,14 +1,16 @@
-#version 120
+#version 330
 
 uniform sampler2D lightmap;
 uniform sampler2D texture;
 
-varying vec2 lmcoord;
-varying vec2 texcoord;
-varying vec4 glcolor;
+in vec2 lmcoord;
+in vec2 texcoord;
+in vec4 glcolor;
+
+out vec4 out_color;
 
 void main() {
-	vec4 color = texture2D(texture, texcoord) * glcolor;
+        vec4 color = texture(texture, texcoord) * glcolor;
 
-	gl_FragData[0] = color;
+        out_color = color;
 }


### PR DESCRIPTION
## Summary
- bump GLSL version to 330 for remaining shaders
- modernize all vertex/fragment shaders to use `in`/`out` variables
- swap deprecated `texture2D` calls for `texture`
- replace `ftransform` and built-in attributes with manual matrix math

## Testing
- `python viewer.py shaders/gbuffers_basic.vsh shaders/gbuffers_basic.fsh` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_687441b0511c83309281cb678ccf0e8a