### PR TITLE
Rename texture uniform

### DIFF
--- a/shaders/gbuffers_armor_glint.fsh
+++ b/shaders/gbuffers_armor_glint.fsh
@@ -1,7 +1,7 @@
 #version 330
 
 uniform sampler2D lightmap;
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 lmcoord;
 in vec2 texcoord;
@@ -10,7 +10,7 @@ in vec4 glcolor;
 out vec4 out_color;
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
         color *= texture(lightmap, lmcoord);
 
 /* DRAWBUFFERS:0 */

--- a/shaders/gbuffers_beaconbeam.fsh
+++ b/shaders/gbuffers_beaconbeam.fsh
@@ -1,6 +1,6 @@
 #version 330
 
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 texcoord;
 in vec4 glcolor;
@@ -8,7 +8,7 @@ in vec4 glcolor;
 out vec4 out_color;
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
 
 /* DRAWBUFFERS:0 */
         out_color = color; // gcolor

--- a/shaders/gbuffers_clouds.fsh
+++ b/shaders/gbuffers_clouds.fsh
@@ -1,6 +1,6 @@
 #version 330
 
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 texcoord;
 in vec4 glcolor;
@@ -8,7 +8,7 @@ in vec4 glcolor;
 out vec4 out_color;
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
 
 /* DRAWBUFFERS:0 */
         out_color = color; // gcolor

--- a/shaders/gbuffers_entities.fsh
+++ b/shaders/gbuffers_entities.fsh
@@ -7,7 +7,7 @@ uniform sampler2D lightmap;
 uniform sampler2D shadowcolor0;
 uniform sampler2D shadowtex0;
 uniform sampler2D shadowtex1;
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 lmcoord;
 in vec2 texcoord;
@@ -22,7 +22,7 @@ const bool shadowtex0Nearest = true;
 const bool shadowtex1Nearest = true;
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
         vec2 lm = lmcoord;
 	if (shadowPos.w > 0.0) {
 		//surface is facing towards shadowLightPosition

--- a/shaders/gbuffers_hand.fsh
+++ b/shaders/gbuffers_hand.fsh
@@ -7,7 +7,7 @@ uniform sampler2D lightmap;
 uniform sampler2D shadowcolor0;
 uniform sampler2D shadowtex0;
 uniform sampler2D shadowtex1;
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 lmcoord;
 in vec2 texcoord;
@@ -22,7 +22,7 @@ const bool shadowtex0Nearest = true;
 const bool shadowtex1Nearest = true;
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
         vec2 lm = lmcoord;
 	if (shadowPos.w > 0.0) {
 		//surface is facing towards shadowLightPosition

--- a/shaders/gbuffers_skytextured.fsh
+++ b/shaders/gbuffers_skytextured.fsh
@@ -1,6 +1,6 @@
 #version 330
 
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 texcoord;
 in vec4 glcolor;
@@ -8,7 +8,7 @@ in vec4 glcolor;
 out vec4 out_color;
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
 
 /* DRAWBUFFERS:0 */
         out_color = color; // gcolor

--- a/shaders/gbuffers_terrain.fsh
+++ b/shaders/gbuffers_terrain.fsh
@@ -7,7 +7,7 @@ uniform sampler2D lightmap;
 uniform sampler2D shadowcolor0;
 uniform sampler2D shadowtex0;
 uniform sampler2D shadowtex1;
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 lmcoord;
 in vec2 texcoord;
@@ -30,7 +30,7 @@ const bool shadowtex1Nearest = true;
 #include "/latinium_lighting.glsl"
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
         vec2 lm = lmcoord;
 	if (shadowPos.w > 0.0) {
 		//surface is facing towards shadowLightPosition

--- a/shaders/gbuffers_textured.fsh
+++ b/shaders/gbuffers_textured.fsh
@@ -7,7 +7,7 @@ uniform sampler2D lightmap;
 uniform sampler2D shadowcolor0;
 uniform sampler2D shadowtex0;
 uniform sampler2D shadowtex1;
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 #include "latinium_lighting.glsl"
 
@@ -27,7 +27,7 @@ const bool shadowtex0Nearest = true;
 const bool shadowtex1Nearest = true;
 
 void main() {
-    vec4 color = texture(texture, texcoord) * glcolor;
+    vec4 color = texture(diffuseTexture, texcoord) * glcolor;
     vec2 lm = lmcoord;
 
     #if COLORED_SHADOWS == 0

--- a/shaders/gbuffers_weather.fsh
+++ b/shaders/gbuffers_weather.fsh
@@ -1,6 +1,6 @@
 #version 330
 
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 texcoord;
 in vec4 glcolor;
@@ -8,6 +8,6 @@ in vec4 glcolor;
 out vec4 out_color;
 
 void main() {
-    vec4 color = texture(texture, texcoord) * glcolor;
+    vec4 color = texture(diffuseTexture, texcoord) * glcolor;
     out_color = color; // gcolor
 }

--- a/shaders/shadow.fsh
+++ b/shaders/shadow.fsh
@@ -1,7 +1,7 @@
 #version 330
 
 uniform sampler2D lightmap;
-uniform sampler2D texture;
+uniform sampler2D diffuseTexture;
 
 in vec2 lmcoord;
 in vec2 texcoord;
@@ -10,7 +10,7 @@ in vec4 glcolor;
 out vec4 out_color;
 
 void main() {
-        vec4 color = texture(texture, texcoord) * glcolor;
+        vec4 color = texture(diffuseTexture, texcoord) * glcolor;
 
         out_color = color;
 }

--- a/viewer.py
+++ b/viewer.py
@@ -23,7 +23,7 @@ SCRIPT_DIR = Path(__file__).parent
 MODEL_PATH = SCRIPT_DIR / "models" / "Box.glb"
 
 IRIS_TEXTURE_UNITS = {
-    "texture": 0,
+    "diffuseTexture": 0,
     "lightmap": 1,
     "shadowtex0": 2,
     "shadowtex1": 3,


### PR DESCRIPTION
## Summary
- rename sampler2D uniform `texture` to `diffuseTexture` in fragments
- update viewer texture unit map for new uniform

## Testing
- `python -m py_compile viewer.py overlay.py utils/*.py watcher.py`
- `python viewer.py` *(fails: `GLFWError` DISPLAY variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874477b5b488330a13e5d76f6d450ca